### PR TITLE
add missing doi to reference

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -111,6 +111,7 @@
     volume={445},
     pages={51--56},
     year={2010},
+    doi={10.25080/Majora-92bf1922-00a},
     address={Austin, TX}
 }
 


### PR DESCRIPTION
Adds a missing DOI to the refence titled: "Data structures for statistical computing in python"